### PR TITLE
Typo fixes

### DIFF
--- a/lessons/2-open-web.md
+++ b/lessons/2-open-web.md
@@ -52,6 +52,6 @@ Flatten and stretch the dough. Cover with tomatoes and cheese. Bake in the oven 
 
 In open source, "forking" is the idea of using someone else's project as the starter point for your own (just like our pizza recipe). I've created a simple profile page page using [Mozilla Thimble](https://thimble.webmaker.org/).
 
-1. Visit my sample profile page](https://d157rqmxrxj6ey.cloudfront.net/adamscott/24988).
+1. Visit my sample profile page (https://d157rqmxrxj6ey.cloudfront.net/adamscott/24988).
 2. Click the "Remix" button at the top of the page.
 3. Though we haven't yet learned and HTML or CSS, see how much you can customize the page. Make it about yourself, a person you look up to, or your own pet.

--- a/lessons/3-html-intro.md
+++ b/lessons/3-html-intro.md
@@ -43,7 +43,7 @@ Some elements do not contain other elements. For example, the image tag ("<img>"
 
 ## Common HTML terms
 
-- **Elements:** Elements define the semantic meaning of their content. Elements include everything between two matching element tags, including the tags themselves. For example, the "<p>" element indicates a paragraph; the "<img>" element indicates an image.
+- **Elements:** Elements define the semantic meaning of their content. Elements include everything between two matching element tags, including the tags themselves. For example, the `<p>` element indicates a paragraph; the `<img>` element indicates an image.
 - **Tags:** HTML documents are written in plain text. They can be written in any text editor that allows content to be saved as plain text, such as Notepad, Notepad++, or Sublime,  but most HTML authors prefer to use a specialized editor that highlights syntax and shows the DOM. Tag names may be written in either upper or lower case. However, the W3C (the global consortium that maintains the HTML standard) recommends using lower case.
 - **Attributes:** The tag may contain additional information and Such information is called an attribute. Tags such as `<img>` and `<a>` use attributes. Attributes usually consist of 2 parts:
     - An attribute name (such as `src` or `href`)


### PR DESCRIPTION
- removed ']' from Lesson 2 > Activity 3 > Step 1 following "Visit my sample profile page"
- fixed p and img element tags in Lesson 3 > Common HTML terms > Elements by removing double quote wrappers